### PR TITLE
Test de maximumResponses avec extractParams

### DIFF
--- a/api/params/__tests__/autocomplete.js
+++ b/api/params/__tests__/autocomplete.js
@@ -166,6 +166,17 @@ test('extractParams', t => {
   })
 })
 
+test('extractParams / maximumResponses', t => {
+  t.deepEqual(extractParams({
+    text: 'foo',
+    maximumResponses: '5'
+  }), {
+    text: 'foo',
+    maximumResponses: 5,
+    type: ['PositionOfInterest', 'StreetAddress']
+  })
+})
+
 test('extractParams / missing text parameter', t => {
   const error = t.throws(() => extractParams({}), {message: 'Failed parsing query'})
   t.deepEqual(error.detail, ['text is a required param'])

--- a/api/params/__tests__/autocomplete.js
+++ b/api/params/__tests__/autocomplete.js
@@ -1,5 +1,6 @@
 import test from 'ava'
 import {extractParam} from '../../util/params.js'
+import {normalizeQuery} from '../../util/querystring.js'
 import {AUTOCOMPLETE, extractParams, isTerrValid, validateBbox, validateLonlat} from '../autocomplete.js'
 
 test('isTerrValid', t => {
@@ -74,7 +75,7 @@ test('extractParam / terr', t => {
 
 test('extractParam / poiType', t => {
   function extractPoiType(poiType) {
-    return extractParam({poiType}, 'poiType', AUTOCOMPLETE.poiType, AUTOCOMPLETE)
+    return extractParam(normalizeQuery({poiType}), 'poiType', AUTOCOMPLETE.poiType, AUTOCOMPLETE)
   }
 
   t.deepEqual(extractPoiType('aérodrome'), ['aérodrome'])
@@ -114,7 +115,7 @@ test('extractParam / type', t => {
 
 test('extractParam / maximumResponses', t => {
   function extractMaximumResponses(maximumResponses) {
-    return extractParam({maximumResponses}, 'maximumResponses', AUTOCOMPLETE.maximumResponses, AUTOCOMPLETE)
+    return extractParam(normalizeQuery({maximumResponses}), 'maximumResponses', AUTOCOMPLETE.maximumResponses, AUTOCOMPLETE)
   }
 
   t.is(extractMaximumResponses('1'), 1)

--- a/api/util/params.js
+++ b/api/util/params.js
@@ -116,7 +116,7 @@ export function parseArrayValues(values, type) {
 export function extractParam(query, paramName, definition) {
   const {type, array, allowedValues, required, defaultValue, nameInQuery, validate, extract} = definition
 
-  const rawValue = query[nameInQuery || paramName]
+  const rawValue = query[(nameInQuery || paramName).toLowerCase()]
   let parsedValue
 
   // Parsing


### PR DESCRIPTION
Cette PR ajoute un test de la fonction `extractParams`.

Ce test concerne le paramètre `maximumResponses`.

Étant un camelCase, la fonction `extractParams` ne le reconnaît pas en tant que paramètre de `AUTOCOMPLETE`.

Du coup la fonction retourne la valeur par défaut 10 au lieu de la valeur envoyée.