### PR TITLE
Corrige l'erreur quand postcode est indéfini 

### DIFF
--- a/api/operations/autocomplete.js
+++ b/api/operations/autocomplete.js
@@ -83,7 +83,7 @@ export function formatResult(result) {
         country: 'PositionOfInterest',
         names: feature.properties.name,
         city: feature.properties.city,
-        zipcode: feature.properties.postcode[0],
+        zipcode: feature.properties.postcode?.[0],
         zipcodes: feature.properties.postcode,
         metropole: feature.properties.citycode.slice(0, 2) < '97',
         poiType: feature.properties.category,


### PR DESCRIPTION
Cette PR corrige l'erreur provoquée quand `postcode` est undefined : `Cannot read properties of undefined (reading '0')`
