### PR TITLE
Assurer que la propriété fulltext est une chaîne de caractères

### DIFF
--- a/api/operations/__tests__/autocomplete.js
+++ b/api/operations/__tests__/autocomplete.js
@@ -192,4 +192,6 @@ test('computeFulltext', t => {
   t.is(computeFulltext({name: 'Location B', postcode: '12345'}), 'Location B, 12345')
   t.is(computeFulltext({name: 'Location C', city: 'City A'}), 'Location C, City A')
   t.is(computeFulltext({name: 'Location D', postcode: '12345', city: 'City B'}), 'Location D, 12345 City B')
+  t.is(computeFulltext({name: ['Location E', 'Location F'], postcode: ['12345', '654321'], city: 'City B'}), 'Location E, 12345 City B')
+  t.is(computeFulltext({name: ['Location G']}), 'Location G')
 })

--- a/api/operations/autocomplete.js
+++ b/api/operations/autocomplete.js
@@ -61,11 +61,11 @@ export function formatAutocompleteParams(params) {
 }
 
 export function computeFulltext(properties) {
-  let fulltext = properties.name
-  const {postcode, city} = properties
+  const {name, postcode, city} = properties
+  let fulltext = Array.isArray(name) ? name[0] : name
 
   if (postcode) {
-    fulltext += city ? `, ${postcode} ${city}` : `, ${postcode}`
+    fulltext += city ? `, ${Array.isArray(postcode) ? postcode[0] : postcode} ${city}` : `, ${postcode}`
   } else if (city) {
     fulltext += `, ${city}`
   }


### PR DESCRIPTION
Cette PR fait en sorte que la propriété `fulltext` soit une chaîne de caractère.

En effet, quand la propriété `name` est un array et qu'il n'y a ni `postcode` ni `city`, la fonction `computeFulltext` retournait donc un array.