### PR TITLE
Corrige la propriété oldMunicipalitycode

### DIFF
--- a/config/open-api/geocode.yaml
+++ b/config/open-api/geocode.yaml
@@ -469,7 +469,7 @@ components:
         city:
           type: string
           description: "Nom de la commune"
-        oldMunicipalitycode:
+        oldmunicipalitycode:
           type: string
           description: "Code de l'ancienne commune"
         districtcode:
@@ -557,7 +557,7 @@ components:
         city:
           type: string
           description: "Nom de la commune"
-        oldMunicipalitycode:
+        oldmunicipalitycode:
           type: string
           description: "Code de l'ancienne commune"
         districtcode:

--- a/indexes/parcel/scripts/build-index/__tests__/transform.js
+++ b/indexes/parcel/scripts/build-index/__tests__/transform.js
@@ -48,7 +48,7 @@ test('transformParcel', t => {
       id: 'featureId',
       departmentcode: 55,
       municipalitycode: 55200,
-      oldMunicipalitycode: 55500,
+      oldmunicipalitycode: 55500,
       districtcode: 55120,
       section: 123,
       sheet: '04',

--- a/indexes/parcel/scripts/build-index/transform.js
+++ b/indexes/parcel/scripts/build-index/transform.js
@@ -7,7 +7,7 @@ export function transformParcel(initialFeature) {
     id: initialFeature.properties.IDU,
     departmentcode: initialFeature.properties.CODE_DEP,
     municipalitycode: initialFeature.properties.CODE_COM,
-    oldMunicipalitycode: initialFeature.properties.COM_ABS,
+    oldmunicipalitycode: initialFeature.properties.COM_ABS,
     districtcode: initialFeature.properties.CODE_ARR,
     section: initialFeature.properties.SECTION,
     sheet: initialFeature.properties.FEUILLE.toString().padStart(2, '0'),


### PR DESCRIPTION
Cette PR corrige la propriété `oldMunicipalitycode` lors du build de l'index parcel et dans la documentation open API.
`oldMunicipalitycode` => `oldmunicipalitycode`