### PR TITLE
Corrige le type des paramètres `poiTypes` et `category`

### DIFF
--- a/api/operations/__tests__/autocomplete.js
+++ b/api/operations/__tests__/autocomplete.js
@@ -49,7 +49,7 @@ test('formatAutocompleteParams / with poiType', t => {
   const params = {
     text: 'search text',
     type: ['PositionOfInterest'],
-    poiType: ['administratif', 'sommet'],
+    poiType: 'administratif',
     maximumResponses: 5,
     lonlat: [2, 40]
   }
@@ -60,7 +60,7 @@ test('formatAutocompleteParams / with poiType', t => {
     q: 'search text',
     autocomplete: true,
     indexes: ['poi'],
-    category: ['administratif', 'sommet'],
+    category: 'administratif',
     limit: 5,
     lon: 2,
     lat: 40

--- a/api/params/__tests__/autocomplete.js
+++ b/api/params/__tests__/autocomplete.js
@@ -80,10 +80,10 @@ test('extractParam / poiType', t => {
     return extractParam(normalizeQuery({poiType}), 'poiType', AUTOCOMPLETE.poiType, AUTOCOMPLETE)
   }
 
-  t.deepEqual(extractPoiType('aérodrome'), ['aérodrome'])
-  t.deepEqual(extractPoiType('administratif'), ['administratif'])
-  t.deepEqual(extractPoiType('barrage'), ['barrage'])
-  t.deepEqual(extractPoiType('aérodrome,administratif,barrage'), ['aérodrome', 'administratif', 'barrage'])
+  t.is(extractPoiType('aérodrome'), 'aérodrome')
+  t.is(extractPoiType('administratif'), 'administratif')
+  t.is(extractPoiType('barrage'), 'barrage')
+  t.is(extractPoiType('aérodrome,administratif,barrage'), 'aérodrome,administratif,barrage')
   t.is(extractPoiType(''), undefined)
 })
 

--- a/api/params/__tests__/autocomplete.js
+++ b/api/params/__tests__/autocomplete.js
@@ -83,7 +83,6 @@ test('extractParam / poiType', t => {
   t.is(extractPoiType('aérodrome'), 'aérodrome')
   t.is(extractPoiType('administratif'), 'administratif')
   t.is(extractPoiType('barrage'), 'barrage')
-  t.is(extractPoiType('aérodrome,administratif,barrage'), 'aérodrome,administratif,barrage')
   t.is(extractPoiType(''), undefined)
 })
 

--- a/api/params/__tests__/base.js
+++ b/api/params/__tests__/base.js
@@ -243,7 +243,6 @@ test('extractParam / category', t => {
   t.is(extractCategory('aérodrome'), 'aérodrome')
   t.is(extractCategory('administratif'), 'administratif')
   t.is(extractCategory('barrage'), 'barrage')
-  t.is(extractCategory('aérodrome,administratif,barrage'), 'aérodrome,administratif,barrage')
   t.is(extractCategory(''), undefined)
 })
 

--- a/api/params/__tests__/base.js
+++ b/api/params/__tests__/base.js
@@ -240,10 +240,10 @@ test('extractParam / category', t => {
     return extractParam({category}, 'category', PARAMS.category, PARAMS)
   }
 
-  t.deepEqual(extractCategory('aérodrome'), ['aérodrome'])
-  t.deepEqual(extractCategory('administratif'), ['administratif'])
-  t.deepEqual(extractCategory('barrage'), ['barrage'])
-  t.deepEqual(extractCategory('aérodrome,administratif,barrage'), ['aérodrome', 'administratif', 'barrage'])
+  t.is(extractCategory('aérodrome'), 'aérodrome')
+  t.is(extractCategory('administratif'), 'administratif')
+  t.is(extractCategory('barrage'), 'barrage')
+  t.is(extractCategory('aérodrome,administratif,barrage'), 'aérodrome,administratif,barrage')
   t.is(extractCategory(''), undefined)
 })
 

--- a/api/params/autocomplete.js
+++ b/api/params/autocomplete.js
@@ -79,7 +79,6 @@ export const AUTOCOMPLETE = {
 
   poiType: {
     type: 'string',
-    array: true,
     description: 'filtre sur le localisant pour le type de POI',
     example: 'administratif'
   },

--- a/api/params/base.js
+++ b/api/params/base.js
@@ -159,7 +159,6 @@ export const PARAMS = {
 
   category: {
     type: 'string',
-    array: true,
     description: 'filtre pour l’index poi. Il permet de filtrer par catégorie de poi',
     example: 'administratif'
   },


### PR DESCRIPTION
Cette PR corrige le type attendu pour les paramètres `poiType` et `category`.
En effet ces paramètres ne prennent qu'une valeur et ne peuvent être des array.