### PR TITLE
Corrige les résulats de `formatResult`

### DIFF
--- a/api/operations/__tests__/autocomplete.js
+++ b/api/operations/__tests__/autocomplete.js
@@ -218,8 +218,14 @@ test('computePoiCity', t => {
 })
 
 test('computeFulltext', t => {
-  t.is(computeFulltext({name: 'Location A'}), 'Location A')
-  t.is(computeFulltext({name: 'Location B', postcode: '12345'}), 'Location B, 12345')
-  t.is(computeFulltext({name: 'Location C', city: 'City A'}), 'Location C, City A')
-  t.is(computeFulltext({name: 'Location D', postcode: '12345', city: 'City B'}), 'Location D, 12345 City B')
+  t.is(computeFulltext({name: ['Location A']}), 'Location A')
+  t.is(computeFulltext({name: ['Location B'], postcode: '12345'}), 'Location B, 12345')
+  t.is(computeFulltext({name: ['Location C'], city: 'City A'}), 'Location C, City A')
+  t.is(computeFulltext({name: ['Location D'], postcode: '12345', city: 'City B'}), 'Location D, 12345 City B')
+  t.is(computeFulltext({name: ['Location E', 'Location F'], postcode: ['12345', '654321'], city: 'City B'}), 'Location E, 12345 City B')
+  t.is(computeFulltext({name: ['Location G']}), 'Location G')
+  t.is(computeFulltext({street: 'Location H', city: 'City A'}), 'Location H, City A')
+  t.is(computeFulltext({street: 'Location I', postcode: '12345', city: 'City B'}), 'Location I, 12345 City B')
+  t.is(computeFulltext({street: 'Location J', postcode: '12345'}), 'Location J, 12345')
+  t.is(computeFulltext({name: ['Location K'], street: 'Location L', postcode: '12345'}), 'Location K, 12345')
 })

--- a/api/operations/__tests__/autocomplete.js
+++ b/api/operations/__tests__/autocomplete.js
@@ -1,5 +1,5 @@
 import test from 'ava'
-import {computeFulltext, formatAutocompleteParams, formatResult, getCenterFromCoordinates} from '../autocomplete.js'
+import {computeFulltext, computePoiCity, formatAutocompleteParams, formatResult, getCenterFromCoordinates} from '../autocomplete.js'
 
 test('getCenterFromCoordinates', t => {
   t.is(getCenterFromCoordinates({}), undefined)
@@ -207,6 +207,14 @@ test('formatResult', t => {
       }
     ]
   })
+})
+
+test('computePoiCity', t => {
+  t.is(computePoiCity(['City A']), 'City A')
+  t.is(computePoiCity(['City B', 'City C']), 'City B')
+  t.is(computePoiCity([]), undefined)
+  t.is(computePoiCity(null), undefined)
+  t.is(computePoiCity(undefined), undefined)
 })
 
 test('computeFulltext', t => {

--- a/api/operations/__tests__/autocomplete.js
+++ b/api/operations/__tests__/autocomplete.js
@@ -77,7 +77,6 @@ test('formatResult', t => {
           postcode: '12345',
           street: 'Street1',
           citycode: '97001',
-          name: 'Location1',
           score: 0.9
         },
         geometry: {
@@ -91,7 +90,6 @@ test('formatResult', t => {
           postcode: '12346',
           street: 'Street2',
           citycode: '97001',
-          name: 'Location2',
           score: 0.8
         },
         geometry: {
@@ -102,8 +100,8 @@ test('formatResult', t => {
     poi: [
       {
         properties: {
-          name: 'POI1',
-          city: 'City B',
+          name: ['POI1'],
+          city: ['City B'],
           postcode: ['97124'],
           citycode: '97123',
           category: 'administratif',
@@ -117,8 +115,8 @@ test('formatResult', t => {
       },
       {
         properties: {
-          name: 'POI2',
-          city: 'City C',
+          name: ['POI2'],
+          city: ['City C'],
           postcode: ['97125'],
           citycode: '97122',
           category: 'administratif',
@@ -145,7 +143,7 @@ test('formatResult', t => {
           zipcode: '12345',
           street: 'Street1',
           metropole: false,
-          fulltext: 'Location1, 12345 City A',
+          fulltext: 'Street1, 12345 City A',
           x: 12.34,
           y: 56.78,
           classification: 7,
@@ -160,7 +158,7 @@ test('formatResult', t => {
           zipcode: '12346',
           street: 'Street2',
           metropole: false,
-          fulltext: 'Location2, 12346 City B',
+          fulltext: 'Street2, 12346 City B',
           x: 2,
           y: 40,
           classification: 7,
@@ -172,7 +170,7 @@ test('formatResult', t => {
       {
         properties: {
           country: 'PositionOfInterest',
-          names: 'POI1',
+          names: ['POI1'],
           city: 'City B',
           zipcode: '97124',
           zipcodes: ['97124'],
@@ -190,7 +188,7 @@ test('formatResult', t => {
       {
         properties: {
           country: 'PositionOfInterest',
-          names: 'POI2',
+          names: ['POI2'],
           city: 'City C',
           zipcode: '97125',
           zipcodes: ['97125'],

--- a/api/operations/autocomplete.js
+++ b/api/operations/autocomplete.js
@@ -64,6 +64,16 @@ export function formatAutocompleteParams(params) {
   return formattedParams
 }
 
+export function computePoiCity(city) {
+  if (city && Array.isArray(city) && city.length === 0) {
+    return
+  }
+
+  if (city) {
+    return Array.isArray(city) && city.length > 0 ? city[0] : city
+  }
+}
+
 export function computeFulltext(properties) {
   let fulltext = properties.name
   const {postcode, city} = properties

--- a/api/operations/autocomplete.js
+++ b/api/operations/autocomplete.js
@@ -75,13 +75,20 @@ export function computePoiCity(city) {
 }
 
 export function computeFulltext(properties) {
-  let fulltext = properties.name
-  const {postcode, city} = properties
+  const {postcode, name, street} = properties
+  const city = computePoiCity(properties.city)
+  let fulltext = ''
+
+  if (name || street) {
+    fulltext = name?.[0] || street
 
   if (postcode) {
-    fulltext += city ? `, ${postcode} ${city}` : `, ${postcode}`
+      fulltext += city ? `, ${Array.isArray(postcode) ? postcode[0] : postcode} ${city}` : `, ${postcode}`
   } else if (city) {
     fulltext += `, ${city}`
+    }
+  } else if (postcode) {
+    fulltext = city ? `${postcode} ${city}` : `${postcode}`
   }
 
   return fulltext

--- a/api/operations/autocomplete.js
+++ b/api/operations/autocomplete.js
@@ -82,10 +82,10 @@ export function computeFulltext(properties) {
   if (name || street) {
     fulltext = name?.[0] || street
 
-  if (postcode) {
+    if (postcode) {
       fulltext += city ? `, ${Array.isArray(postcode) ? postcode[0] : postcode} ${city}` : `, ${postcode}`
-  } else if (city) {
-    fulltext += `, ${city}`
+    } else if (city) {
+      fulltext += `, ${city}`
     }
   } else if (postcode) {
     fulltext = city ? `${postcode} ${city}` : `${postcode}`
@@ -115,13 +115,13 @@ export function formatResult(result) {
     } else if (r === 'poi') {
       autocompleteResult.poi = result[r].map(feature => ({properties: {
         country: 'PositionOfInterest',
-        names: feature.properties.name,
-        city: feature.properties.city,
+        names: feature.properties?.name,
+        city: computePoiCity(feature.properties.city),
         zipcode: feature.properties.postcode?.[0],
         zipcodes: feature.properties.postcode,
         metropole: feature.properties.citycode ? feature.properties.citycode.slice(0, 2) < '97' : undefined,
         poiType: feature.properties.category,
-        street: feature.properties.category.includes('administratif') || feature.properties.category.includes('commune') ? feature.properties.city : feature.properties.toponym,
+        street: feature.properties.category.includes('administratif') || feature.properties.category.includes('commune') ? computePoiCity(feature.properties.city) : feature.properties.toponym,
         kind: feature.properties.toponym,
         fulltext: computeFulltext(feature.properties),
         x: feature.geometry.coordinates[0],


### PR DESCRIPTION
Cette PR corrige les résultats que retournent la fonction `formatResult`.
Une nouvelle fonction a été ajoutée (`computePoiCity`) et `computeFulltext` a été améliorée.