### PR TITLE
Corrige la fonction `computeFulltext`

### DIFF
--- a/api/operations/__tests__/autocomplete.js
+++ b/api/operations/__tests__/autocomplete.js
@@ -226,4 +226,5 @@ test('computeFulltext', t => {
   t.is(computeFulltext({street: 'Location I', postcode: '12345', city: 'City B'}), 'Location I, 12345 City B')
   t.is(computeFulltext({street: 'Location J', postcode: '12345'}), 'Location J, 12345')
   t.is(computeFulltext({name: ['Location K'], street: 'Location L', postcode: '12345'}), 'Location K, 12345')
+  t.is(computeFulltext({name: 'Location M', street: 'Location L', postcode: '12345'}), 'Location M, 12345')
 })

--- a/api/operations/autocomplete.js
+++ b/api/operations/autocomplete.js
@@ -80,7 +80,7 @@ export function computeFulltext(properties) {
   let fulltext = ''
 
   if (name || street) {
-    fulltext = name?.[0] || street
+    fulltext = (Array.isArray(name) && name[0]) || (!Array.isArray(name) && name) || street
 
     if (postcode) {
       fulltext += city ? `, ${Array.isArray(postcode) ? postcode[0] : postcode} ${city}` : `, ${postcode}`


### PR DESCRIPTION
Cette PR corrige la fonction `computeFulltext`. 
Le name pouvant être une string quand il s'agit d'une adresse ou un array quand il s'agit d'un POI, la condition liée à `fulltext` a été mise à jour.