### PR TITLE
Corrige la route `/completion`

### DIFF
--- a/api/__tests__/router.js
+++ b/api/__tests__/router.js
@@ -210,7 +210,7 @@ test('getCapabilities / autocomplete', async t => {
   app.use('/', router)
 
   const response = await request(app)
-    .get('/autocomplete/getCapabilities')
+    .get('/completion/getCapabilities')
 
   t.is(response.status, 200)
   t.truthy(response.body.api)
@@ -237,7 +237,7 @@ test('openAPI / completion.yaml', async t => {
   app.use('/', router)
 
   const response = await request(app)
-    .get('/autocomplete/openapi/completion.yaml')
+    .get('/completion/openapi/completion.yaml')
 
   t.is(response.status, 200)
   t.is(response.headers['content-type'], 'text/yaml; charset=UTF-8')

--- a/api/router.js
+++ b/api/router.js
@@ -62,7 +62,7 @@ export default function createRouter(options = {}) {
     res.send(capabilities)
   }))
 
-  router.get('/autocomplete/getCapabilities', w(async (req, res) => {
+  router.get('/completion/getCapabilities', w(async (req, res) => {
     const capabilities = await computeAutocompleteCapabilities()
     res.send(capabilities)
   }))
@@ -71,7 +71,7 @@ export default function createRouter(options = {}) {
     res.sendFile(path.resolve('./config/open-api/geocode.yaml'))
   }))
 
-  router.get('/autocomplete/openapi/completion.yaml', w((req, res) => {
+  router.get('/completion/openapi/completion.yaml', w((req, res) => {
     res.sendFile(path.resolve('./config/open-api/completion.yaml'))
   }))
 


### PR DESCRIPTION
Cette PR corrige la route `/completion`.

Remplace `/autocomplete` par `/completion`.